### PR TITLE
Update falcon-sensor to 7.33.0-18606

### DIFF
--- a/bootstrap-mozscapecawl-24.sh
+++ b/bootstrap-mozscapecawl-24.sh
@@ -87,8 +87,8 @@ echo "nameserver 127.0.0.1" > /etc/resolv.conf
 # netstat -lnp| grep :53
 
 #crowdstrike
-curl https://infos.moz.com/falcon-sensor_7.11.0-16407_amd64.deb -Os
-apt install -y ./falcon-sensor_7.11.0-16407_amd64.deb
+curl https://infos.moz.com/falcon-sensor_7.33.0-18606_amd64.deb -Os
+apt install -y ./falcon-sensor_7.33.0-18606_amd64.deb
 /opt/CrowdStrike/falconctl -s --cid=$CROWDSTRIKE_KEY
 /opt/CrowdStrike/falconctl -s --tags="IDINA-CRAWLER,PROD"
 systemctl start falcon-sensor

--- a/bootstrap-mozscapecawl-ubuntu14.sh
+++ b/bootstrap-mozscapecawl-ubuntu14.sh
@@ -102,8 +102,8 @@ echo "session required pam_limits.so" >> /etc/pam.d/common-session-noninteractiv
 perl -pi -e 's/\#PasswordAuthentication yes/PasswordAuthentication no/' /etc/ssh/sshd_config
 
 # Install Crowdstrike
-curl  https://infos.moz.com/falcon-sensor_6.26.0-12303_amd64.deb -Os
-dpkg -i falcon-sensor_6.26.0-12303_amd64.deb
+curl  https://infos.moz.com/falcon-sensor_7.33.0-18606_amd64.deb -Os
+dpkg -i falcon-sensor_7.33.0-18606_amd64.deb
 /opt/CrowdStrike/falconctl -s --cid=$CROWDSTRIKE_KEY
 /opt/CrowdStrike/falconctl -s --tags="AWS,Production,Idina,Crawler"
 service falcon-sensor start

--- a/bootstrap-mozscapecawl-ubuntu24.sh
+++ b/bootstrap-mozscapecawl-ubuntu24.sh
@@ -87,8 +87,8 @@ echo "nameserver 127.0.0.1" > /etc/resolv.conf
 # netstat -lnp| grep :53
 
 #crowdstrike
-curl https://infos.moz.com/falcon-sensor_7.11.0-16407_amd64.deb -Os
-apt install -y ./falcon-sensor_7.11.0-16407_amd64.deb
+curl https://infos.moz.com/falcon-sensor_7.33.0-18606_amd64.deb -Os
+apt install -y ./falcon-sensor_7.33.0-18606_amd64.deb
 /opt/CrowdStrike/falconctl -s --cid=$CROWDSTRIKE_KEY
 /opt/CrowdStrike/falconctl -s --tags="IDINA-CRAWLER,PROD"
 systemctl start falcon-sensor


### PR DESCRIPTION
Update falcon-sensor version from older versions to 7.33.0-18606 in bootstrap scripts.

## Changes
- bootstrap-mozscapecawl-ubuntu14.sh: 6.26.0-12303 → 7.33.0-18606
- bootstrap-mozscapecawl-ubuntu24.sh: 7.11.0-16407 → 7.33.0-18606
- bootstrap-mozscapecawl-24.sh: 7.11.0-16407 → 7.33.0-18606

Co-Authored-By: Warp <agent@warp.dev>